### PR TITLE
Add workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+---
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - run: go mod tidy -v
+      - name: "Check for changes in go.mod"
+        run: |
+          git diff --name-only --exit-code go.mod || ( git diff && echo "Run go tidy to update go.mod" && false )
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - run: go mod download
+      - name: "Compile Go code"
+        run: |
+          go build -v ./...
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Enable VRF kernel module"
+        run: sudo apt-get update && sudo apt-get install -y linux-modules-extra-$(uname -r) && sudo modprobe -v vrf
+      - name: "Build images"
+        run: make images
+      - name: "Run Tests"
+        run: make test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+---
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Build images"
+        run: make images
+
+      - name: "List images"
+        run: docker images
+
+      - name: "Login to ghcr.io registry"
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Build and push Docker image"
+        run: make push-images
+


### PR DESCRIPTION
This PR adds initial CI/CD pipelines for StoneWork using GitHub Workflows.

- **CI workflow** - runs check/build/test job for PRs and pushes to main branch
- **Release workflow** - builds and pushes images to GitHub Container Registry

---

The testing examples with mockcnf seem to be failing on command `ip link`  for `vrf1` MTU. I assume it is because of different kernel version. Will need to investigate more. Alternatively we could disable these two tests for GitHub CI for now.