### PR TITLE
Fix image pushing to ghcr.io

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,8 +135,10 @@ endif
 push-images:
 ifneq ($(RELEASE_TAG_CHECKED),)
 	docker push ${REPO}/${STONEWORK_PROD_IMAGE}:${RELEASE_VERSION_FULL}
+ifneq ($(findstring -,$(RELEASE_TAG_CHECKED)),-)
 	docker push ${REPO}/${STONEWORK_PROD_IMAGE}:${RELEASE_VERSION_MAJOR_MINOR}
 	docker push ${REPO}/${STONEWORK_PROD_IMAGE}
+endif
 else
 	@echo "Release tag is empty or has incorrect format."
 	@echo "Supplied release tag: ${RELEASE_TAG}"

--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,9 @@ ifneq ($(RELEASE_TAG_CHECKED),)
 endif
 
 push-images:
+	docker push ${REPO}/${STONEWORK_VPP_IMAGE}:${VPP_VERSION}
+	docker push ${REPO}/${STONEWORK_VPP_IMAGE}
+
 ifneq ($(RELEASE_TAG_CHECKED),)
 	docker push ${REPO}/${STONEWORK_PROD_IMAGE}:${RELEASE_VERSION_FULL}
 ifneq ($(findstring -,$(RELEASE_TAG_CHECKED)),-)


### PR DESCRIPTION
Git tags that contain the -* suffix (e.g. 21.06.1-rc2) will from now on push images to ghcr.io only in the full version format (e.g. 21.06.1-rc2).
This PR also adds the stonework-vpp image to ghcr.io.