### PR TITLE
Fix issues in ABX VPP plugin

### DIFF
--- a/plugins/abx/descriptor/abx.go
+++ b/plugins/abx/descriptor/abx.go
@@ -100,11 +100,13 @@ func (d *ABXDescriptor) EquivalentABXs(key string, oldABX, newABX *abx.ABX) bool
 	if oldABX.AclName != newABX.AclName {
 		return false
 	}
-
-	// compare attached interfaces
-	if len(oldABX.AttachedInterfaces) != len(newABX.AttachedInterfaces) {
+	if oldABX.DstMac != newABX.DstMac {
 		return false
 	}
+	if oldABX.OutputInterface != newABX.OutputInterface {
+		return false
+	}
+	// compare attached interfaces
 	return equivalentABXAttachedInterfaces(oldABX.AttachedInterfaces, newABX.AttachedInterfaces)
 }
 
@@ -201,6 +203,10 @@ func (d *ABXDescriptor) Dependencies(key string, abxData *abx.ABX) (dependencies
 }
 
 func equivalentABXAttachedInterfaces(oldIfs, newIfs []*abx.ABX_AttachedInterface) bool {
+	if len(oldIfs) != len(newIfs) {
+		return false
+	}
+	// compare values in list ignoring order
 	for _, oldIf := range oldIfs {
 		var found bool
 		for _, newIf := range newIfs {

--- a/plugins/abx/vppcalls/abx_vppcalls.go
+++ b/plugins/abx/vppcalls/abx_vppcalls.go
@@ -22,6 +22,7 @@ import (
 	"go.ligato.io/vpp-agent/v3/plugins/vpp"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/aclplugin/aclidx"
 	"go.ligato.io/vpp-agent/v3/plugins/vpp/ifplugin/ifaceidx"
+
 	abx "go.pantheon.tech/stonework/proto/abx"
 )
 
@@ -43,7 +44,7 @@ type ABXVppAPI interface {
 	// GetAbxVersion retrieves version of the VPP ABX plugin
 	GetAbxVersion() (ver string, err error)
 	// AddAbxPolicy creates new ABX entry together with a list of forwarding paths
-	AddAbxPolicy(policyID uint32, aclID uint32, tx_if string, dst_mac string) error
+	AddAbxPolicy(policyID uint32, aclID uint32, txIf string, dstMac string) error
 	// DeleteAbxPolicy removes existing ABX entry
 	DeleteAbxPolicy(policyID uint32) error
 	// AbxAttachInterface attaches interface to the ABX

--- a/vpp/abx/vpp2202/abx/abx.h
+++ b/vpp/abx/vpp2202/abx/abx.h
@@ -28,7 +28,7 @@
 #include <vppinfra/error.h>
 
 #define ABX_PLUGIN_VERSION_MAJOR 1
-#define ABX_PLUGIN_VERSION_MINOR 1
+#define ABX_PLUGIN_VERSION_MINOR 2
 
 typedef struct
 {

--- a/vpp/abx/vpp2202/abx/abx_api.c
+++ b/vpp/abx/vpp2202/abx/abx_api.c
@@ -132,7 +132,7 @@ abx_policy_send_details (
   mp->policy.policy_id = htonl (ap->ap_id);
   mp->policy.acl_index = htonl (ap->ap_acl);
   mp->policy.tx_sw_if_index = htonl (ap->ap_tx_sw_if_index);
-  //  mac_address_encode (ap->ap_mac, &mp->policy.dst_mac);
+  mac_address_encode (&ap->ap_dst_mac, mp->policy.dst_mac);
 
   vl_api_send_msg (ctx->reg, (u8 *) mp);
 

--- a/vpp/abx/vpp2202/abx/abx_if_attach.c
+++ b/vpp/abx/vpp2202/abx/abx_if_attach.c
@@ -213,10 +213,10 @@ abx_if_detach (u32 policy_id, u32 sw_if_index)
                           sw_if_index))
     return (VNET_API_ERROR_INVALID_SW_IF_INDEX);
 
-  /* not a physical port? */
-  sw_if = vnet_get_sw_interface (vnm, sw_if_index);
-  if (sw_if->type != VNET_SW_INTERFACE_TYPE_HARDWARE)
-    return (VNET_API_ERROR_INVALID_SW_IF_INDEX);
+  /* not a physical port? */ // DOES IT MATTER?
+  //sw_if = vnet_get_sw_interface (vnm, sw_if_index);
+  //if (sw_if->type != VNET_SW_INTERFACE_TYPE_HARDWARE)
+  //  return (VNET_API_ERROR_INVALID_SW_IF_INDEX);
 
   /*
    * check this is a valid attachment

--- a/vpp/abx/vpp2202/abx/abx_if_attach.c
+++ b/vpp/abx/vpp2202/abx/abx_if_attach.c
@@ -204,7 +204,6 @@ abx_if_detach (u32 policy_id, u32 sw_if_index)
   abx_if_attach_t *aia;
   u32 index;
   vnet_main_t *vnm = vnet_get_main ();
-  vnet_sw_interface_t * sw_if;
   
   /*
    * check this is a valid interface
@@ -212,11 +211,6 @@ abx_if_detach (u32 policy_id, u32 sw_if_index)
   if (pool_is_free_index (vnm->interface_main.sw_interfaces,
                           sw_if_index))
     return (VNET_API_ERROR_INVALID_SW_IF_INDEX);
-
-  /* not a physical port? */ // DOES IT MATTER?
-  //sw_if = vnet_get_sw_interface (vnm, sw_if_index);
-  //if (sw_if->type != VNET_SW_INTERFACE_TYPE_HARDWARE)
-  //  return (VNET_API_ERROR_INVALID_SW_IF_INDEX);
 
   /*
    * check this is a valid attachment


### PR DESCRIPTION
### ABX VPP plugin
- fix missing DstMac field value in dump details message
- remove useless check if interface is physical on detach (attach does not check this)
- increase ABX plugin version to 1.2

### ABX in vppcalls and descriptor
- incomplete equal comparator did not compare dstmac/output iface
- dump did not resolve output interface
- fix resync of abx attached interfaces
