### PR TITLE
Fix swctl deploy services command

### DIFF
--- a/cmd/swctl/cmd_deploy.go
+++ b/cmd/swctl/cmd_deploy.go
@@ -144,7 +144,7 @@ func newDeploymentServices(cli Cli) *cobra.Command {
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := cli.Exec("docker compose services", args)
+			out, err := cli.Exec("docker compose ps --services", args)
 			if err != nil {
 				return err
 			}

--- a/cmd/swctl/cmd_status.go
+++ b/cmd/swctl/cmd_status.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 
+	"github.com/gookit/color"
 	"github.com/spf13/cobra"
 )
 
@@ -21,7 +22,7 @@ func NewStatusCmd(cli Cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "status [flags]",
 		Short:   "Show status of StoneWork components",
-		Example: statusExample,
+		Example: color.Sprint(statusExample),
 		Args:    cobra.ArbitraryArgs,
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
 			UnknownFlags: true,


### PR DESCRIPTION
Also correct color highlighting for `swctl status -h` command.

Signed-off-by: Peter Motičák [peter.moticak@pantheon.tech](mailto:peter.moticak@pantheon.tech)