### PR TITLE
ci: Fix always passing VPP plugin test

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -35,9 +35,9 @@ vpp)
     -f ./docker/vpp.Dockerfile .
   ;;
 vpp-test)
-  docker build --build-arg VPP_IMAGE="${VPP_IMAGE}" \
+  docker build --progress=plain --build-arg VPP_IMAGE="${VPP_IMAGE}" \
     -t ${IMAGE_TAG} \
-    -f ./docker/vpp-test.Dockerfile . 2>&1 | cat
+    -f ./docker/vpp-test.Dockerfile .
   ;;
 tester)
   docker build \


### PR DESCRIPTION
`docker build` truncated stderr output so it was redirected to stdout so user could read why the test failed. This solution was not made with much foresight, as when automatic CI testing was added later, stderr was always empty so workflow passed even when it should not.
This PR should hopefully fix the issue.

Signed-off-by: Peter Motičák <peter.moticak@pantheon.tech>