### PR TITLE
Migrate to Docker Compose V2

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,15 +148,12 @@ documentation (`*.md`) and some examples to get you started.
 
 #### Requirements
 
-1. StoneWork requires an **Ubuntu VM** or a **bare-metal server** running Ubuntu, preferably version **18.04 (Bionic Beaver)**.
+1. StoneWork requires an **Ubuntu VM** or a **bare-metal server** running Ubuntu, preferably version **20.04 (Focal Fossa)**.
 
 
-2. Next, Docker and docker-compose must be installed.
+2. Next, Docker and Docker Compose plugin must be installed.
 
-   Install with:
-   ```
-   $ apt-get install docker.io docker-compose
-   ```
+   Official manual for installing Docker and Docker Compose can be found [here][install-docker] and [here][install-compose] respectively.
 
 3. **(DPDK Only)** Install/Enable Drivers
    
@@ -203,14 +200,14 @@ documentation (`*.md`) and some examples to get you started.
 
 
 6. Finally, the StoneWork image has to be loaded so that
-   Docker/docker-compose/K8s is able to provision a container instance. Run:
+   Docker/Docker Compose/K8s is able to provision a container instance. Run:
    ```
    $ docker load <./stonework.image
    ```
 
 ## Deployment
 
-StoneWork is deployed using [Docker Compose][docker-compose] version 3.3 or
+StoneWork is deployed using [Docker Compose][compose] version 3.3 or
 newer. StoneWork itself is only a single container (with VPP and StoneWork agent
 inside), but every CNF that is deployed alongside it runs in a **separate
 container**, hence the use of Compose. 
@@ -329,7 +326,9 @@ services:
 [config-pdf]: docs/config/STONEWORK-CONFIG.pdf
 [config-jsonschema]: docs/config/STONEWORK-CONFIG.jsonschema
 [vscode-jsonschema]: https://dev.to/brpaz/how-to-create-your-own-auto-completion-for-json-and-yaml-files-on-vs-code-with-the-help-of-json-schema-k1i
-[docker-compose]: https://docs.docker.com/compose/
+[compose]: https://docs.docker.com/compose/
+[install-docker]: https://docs.docker.com/engine/install/ubuntu/
+[install-compose]: https://docs.docker.com/compose/install/linux/
 [vpp]: https://wiki.fd.io/view/VPP
 [ligato-vpp-agent]: https://github.com/ligato/vpp-agent
 [cdnf-io]: https://cdnf.io/cnf_list/

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ StoneWork Architecture
 CNF Integration
 ---------------
 
-Each CNF remains to be packaged and delivered as a single docker image. The same image can be used to deploy the
+Each CNF remains to be packaged and delivered as a single Docker image. The same image can be used to deploy the
 CNF either as **Standalone** (i.e. inside a chain/mesh of CNFs) or as a **StoneWork Module** or *SW-Module* for short.
 
 Simply by setting the environment variable `CNF_MODE` to `STANDALONE` or `STONEWORK_MODULE`, the CNF will either start
@@ -26,7 +26,7 @@ Instead, every CNF runs as a separate container from its own image, running its 
 manage the single, shared data-plane. 
 
 All (enabled) CNFs and the StoneWork itself are typically orchestrated by
-*docker-compose*. To enable a new CNF feature is then as easy, as to add a container entry into *docker-compose.yaml*
+*Docker Compose*. To enable a new CNF feature is then as easy, as to add a container entry into *docker-compose.yaml*
 for the CNF, restart the deployment and let the StoneWork to discover it.
 
 If a given CNF is never used, it doesn't have to be mentioned in *docker-compose.yaml*

--- a/docs/CNF_HOW_TO.md
+++ b/docs/CNF_HOW_TO.md
@@ -229,7 +229,7 @@ see the [StoneWork Architecture][architecture].
        }
    }
    ```
-   Then, inside dockerfile, call (replace `cnf-init` with the name of your init command):
+   Then, inside Dockerfile, call (replace `cnf-init` with the name of your init command):
    ```
    RUN /usr/local/bin/cnf-init --print-spec > /api/models.spec.yaml
    ```

--- a/docs/UPDATE_PROCEDURE.md
+++ b/docs/UPDATE_PROCEDURE.md
@@ -10,7 +10,7 @@ StoneWork is based on *vpp-agent* and thus supports stable VPP versions, support
 
 Check whether `ligato/vpp-base`, with your desired version, already exists.
 
-To do so, just look at `ligato/vpp-base` tags on [DockerHub][dockerhub-tags]. Or directly by docker pull command, for example:
+To do so, just look at `ligato/vpp-base` tags on [DockerHub][dockerhub-tags]. Or directly by `docker pull` command, for example:
 `docker pull ligato/vpp-base:23.06`
 
 If there is no such tagged version, you need to create it.
@@ -75,7 +75,7 @@ found a compatible API.
 
 ## 2.5 Upload new tag for the StoneWork to image repository
 
-StoneWork docker images are present on [GitHub Container Registry][ghcr].
+StoneWork Docker images are present on [GitHub Container Registry][ghcr].
 
 To update images, create and push a git tag into image repository according to
 the following convention:

--- a/docs/USERGUIDE.md
+++ b/docs/USERGUIDE.md
@@ -7,11 +7,12 @@ StoneWork introduces a **complete routing platform**, based on VPP, running well
 
 Dependencies
 ============
+StoneWork requires an **Ubuntu VM** or a **bare-metal server** running Ubuntu, preferably version **20.04 (Focal Fossa)**.
 
-First of all we need to install Docker and *docker-compose*:
-```
-$ apt-get install docker.io docker-compose
-```
+Other required dependencies of StoneWork are Docker and Docker Compose plugin.
+
+Official manual for installing Docker on Ubuntu can be found [here][install-docker] and for Docker Compose [here][install-compose].
+
 First Steps w/ StoneWork
 ========================
 
@@ -35,7 +36,7 @@ $ docker logs stonework
 When working with StoneWork, it is useful to see the logs of control plane transactions. These are actions
 done by StoneWork to set its dataplane - FD.io VPP. 
 
-By looking at the logs, it can be verified whether concrete transaction were successful or not.
+By looking at the logs, it can be verified whether concrete transactions were successful or not.
 
 To access the StoneWork container:
 ```
@@ -165,22 +166,22 @@ root@44480538e5b0:/# ip add
 ```
 But this tap interface is present only inside our StoneWork container. What if we wanted to expose the tap to our host system?
 
-Then we need to use host network mode in our docker run one liner:
+Then we need to use host network mode in our `docker run` one liner:
 ```
 $ docker run -it --rm --name stonework --privileged --network="host" -e ETCD_CONFIG="" ghcr.io/pantheontech/stonework:23.06
 ```
 For more details about tap interfaces and VPP, take a look [at this example][tap-example].
 
-docker-compose Manifest
-=======================
+Docker Compose File
+===================
 
-As our Docker run one-liner grows, it becomes better to use docker-compose, in terms of readability and maintainability.
+As our `docker run` one-liner grows, it becomes better to use Docker Compose, in terms of readability and maintainability.
 
-Lets rewrite the above mentioned docker run command, i.e.:
+Lets rewrite the above mentioned `docker run` command, i.e.:
 ```
 $ docker run -it --rm --name stonework --privileged --network="host" -e ETCD_CONFIG="" ghcr.io/pantheontech/stonework:23.06
 ```
-into *docker-compose.yaml*:
+into `docker-compose.yaml`:
 ```
 version: '3.3'
 
@@ -195,12 +196,12 @@ services:
 ```
 All of the fields should be obvious, as it is a 1-2-1 translation of the command we used so far.
 
-The StoneWork docker container is then turned on/off by the following commands from the same directory as our docker-compose file is located:
+The StoneWork Docker container is then turned on/off by the following commands from the same directory where our Docker Compose file is located:
 ```
-$ docker-compose up -d
+$ docker compose up -d
 ```
 ```
-$ docker-compose down
+$ docker compose down
 ```
 
 AF_PACKET Interface
@@ -208,9 +209,9 @@ AF_PACKET Interface
 
 Using this interface type, we can easily start using interfaces of the host system in StoneWork.
 
-The downside of the af_packet interface is its performance, so it should be used mainly for testing purposes.
+The downside of the AF_PACKET interface is its performance, so it should be used mainly for testing purposes.
 
-To use the host interfaces using AF_PACKET, the same docker-compose.yaml can be used as the one for TAPs.
+To use the host interfaces using AF_PACKET, the same `docker-compose.yaml` can be used as the one for TAPs.
 
 Now, suppose we have an interface called ens33 and its MAC address is 00:0c:29:0a:93:4d.
 
@@ -248,10 +249,10 @@ Prerequisities
 To enable DPDK interfaces in data plane, few specifics steps must be done, those are well described in the
 [StoneWork README][readme] file, in the [Installation section.](/README.md#Installation)
 
-docker-compose
+Docker Compose
 --------------
 
-To enable DPDK interfaces, we will need to extend our docker-compose a bit more.
+To enable DPDK interfaces, we will need to extend our Docker Compose file a bit more.
 ```
 version: '3.3'
 
@@ -333,7 +334,7 @@ To do so, just uncomment the dpdk part of the config above.
 
 An arbitrary amount of interfaces can be used.
 
-If we now start the docker container, VPP will contain our new DPDK interface:
+If we now start the Docker container, VPP will contain our new DPDK interface:
 ```
 $ docker exec -it stonework vppctl show int
               Name               Idx    State  MTU (L3/IP4/IP6/MPLS)     Counter          Count
@@ -365,7 +366,7 @@ As probably obvious, this configuration is telling StoneWork to set the DPDK int
 
 Now, it's time to wake up StoneWork:
 ```
-$ docker-compose up -d
+$ docker compose up -d
 ```
 And to verify that everything was set properly in the data plane:
 ```
@@ -419,13 +420,13 @@ StoneWork Enterprise
 With StoneWork Enterprise you'll get access to additional control plane features. Enterprise features are packaged
 as container images. To use them you need a valid license. 
 
-First the CNF image must be loaded into docker as:
+First the CNF image must be loaded into Docker as:
 ```
 docker load -i <path/to/image/file>
 ```
 Then, the `docker-compose.yaml` is updated.
 
-Lets demonstrate it on cnf-bgp, this is how the new docker-compose will look like:
+Lets demonstrate it on cnf-bgp, this is how the new Docker Compose file will look like:
 ```
 version: '3.3'
 
@@ -494,7 +495,7 @@ The rest of environment variables have the same meaning as for StoneWork.
 
 Now start the StoneWork with:
 ```
-docker-compose up -d
+docker compose up -d
 ```
 And finally verify that the CNF was successfully discovered by examining the StoneWork logs as:
 ```
@@ -532,6 +533,8 @@ So the `cnf-bgp` introduces new root level entry called bgpConfig, to describe i
 - **10.10.0.10/24** is some other BGP server to connect to and to exchange the routes with
 - **memif-vrf1** is interface towards 10.10.0.10/24. Note, that not neccessarily directly to that network, there might be next hops in between
 
+[install-docker]: https://docs.docker.com/engine/install/ubuntu/
+[install-compose]: https://docs.docker.com/compose/install/linux/
 [vpp-hugepages]: https://fd.io/docs/vpp/master/gettingstarted/users/configuring/hugepages.html
 [vpp-startup]: https://my-vpp-docs.readthedocs.io/en/latest/gettingstarted/users/configuring/startup.html
 [agentctl-link]: https://docs.ligato.io/en/latest/user-guide/agentctl/

--- a/examples/getting-started/README.md
+++ b/examples/getting-started/README.md
@@ -21,9 +21,9 @@ Deployment Description
 
 This example consists of two YAML-formatted files:
  - `docker-compose.yaml`: describes how to deploy the StoneWork container in the
-   [Docker-Compose][docker-compose] language. While in this example there is
+   [Docker Compose][compose-plugin] language. While in this example there is
    only **one container** - StoneWork itself - it is still advised to take this
-   opportunity and learn how to work with docker-compose. Extending StoneWork's
+   opportunity and learn how to work with Docker Compose. Extending StoneWork's
    feature-set with any of the CNFs from the PANTHEON.tech
    [cloud-native network functions portfolio][cdnf-portfolio] requires deploying additional containers
    alongside StoneWork, hence the use of *Compose*. The content of
@@ -60,7 +60,7 @@ Interacting with StoneWork
 
 In order to deploy StoneWork, simply run (from within this directory):
 ```
-$ docker-compose up -d
+$ docker compose up -d
 ```
 The StoneWork container should be present almost immediately:
 ```
@@ -101,7 +101,7 @@ rtt min/avg/max/mdev = 0.247/0.492/0.839/0.251 ms
 
 Let's enter the VPP CLI:
 ```
-$ docker-compose exec -it stonework vppctl
+$ docker compose exec -it stonework vppctl
     _______    _        _   _____  ___ 
  __/ __/ _ \  (_)__    | | / / _ \/ _ \
  _/ _// // / / / _ \   | |/ / ___/ ___/
@@ -147,7 +147,7 @@ StoneWork container.
 
 Obtain the currently running configuration with:
 ```
-$ docker-compose exec stonework agentctl config get 2>/dev/null
+$ docker compose exec stonework agentctl config get 2>/dev/null
 netallocConfig: {}
 linuxConfig:
   interfaces:
@@ -210,7 +210,7 @@ linuxConfig:
 Remember, that the config dir is mounted into
 the container under `/etc/stonework/config`. Apply the new, desired config with:
 ```
-$ docker-compose exec stonework agentctl config update --replace /etc/stonework/config/new-config.yaml
+$ docker compose exec stonework agentctl config update --replace /etc/stonework/config/new-config.yaml
 ```
 Observe the performed config changes:
 ```
@@ -223,7 +223,7 @@ vpp: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
         RX errors 0  dropped 0  overruns 0  frame 0
         TX packets 77  bytes 11885 (11.8 KB)
         TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
-$ docker-compose exec stonework vppctl show interface address
+$ docker compose exec stonework vppctl show interface address
 local0 (dn):
 tap0 (up):
   L3 192.168.222.3/30
@@ -274,18 +274,18 @@ $ curl -v --header "Content-Type: application/yaml" --request PUT --data-binary 
 To observe what is happening behind the scenes and to debug any potential issues,
 obtain StoneWork logs with:
 ```
-$ docker-compose logs stonework
+$ docker compose logs stonework
 ```
 
 ### Shutdown & Undeploy
 
 Finally, to shutdown and undeploy StoneWork container, simply run:
 ```
-$ docker-compose down
+$ docker compose down
 ```
 
 
-[docker-compose]: https://docs.docker.com/compose/
+[compose-plugin]: https://docs.docker.com/compose/
 [config]: ../../docs/config/STONEWORK-CONFIG.md
 [readme]: ../../README.md
 [cdnf-portfolio]: https://cdnf.io/cnf_list/

--- a/examples/nat-router/README.md
+++ b/examples/nat-router/README.md
@@ -60,14 +60,14 @@ Running the Example
 Once the configuration is updated to match the actual environment, deploy
 StoneWork using:
 ```
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 Initially, only physical interfaces should be configured.
 
 To verify this, run:
 ```
-$ docker-compose exec stonework vppctl show interface address
+$ docker compose exec stonework vppctl show interface address
 gbe-private-net (up):
   L3 192.168.1.1/24
 gbe-public-net (up):
@@ -77,14 +77,14 @@ local0 (dn):
 
 Explore the CLI provided by StoneWork:
 ```
-$ docker-compose exec stonework agentctl --help
+$ docker compose exec stonework agentctl --help
 ```
 
 ## Add & Enable NAT Config
 
 For example, to **add and enable NAT configuration**, run:
 ```
-$ docker-compose exec stonework agentctl config update /etc/stonework/config/add-nat-config.yaml
+$ docker compose exec stonework agentctl config update /etc/stonework/config/add-nat-config.yaml
 ```
 `add-nat-config.yaml` is mounted from `./config/add-nat-config.yaml`.
 
@@ -97,7 +97,7 @@ network should be able to access servers in the public network(s).
 
 Observe the NAT in process using packet tracing on VPP (only `SYN` packet shown):
 ```
-$ docker-compose exec stonework vpptrace.sh -i dpdk
+$ docker compose exec stonework vpptrace.sh -i dpdk
 
 00:04:40:604246: dpdk-input
   gbe-private-net rx queue 0

--- a/examples/telemetry-monitoring/test-stonework.sh
+++ b/examples/telemetry-monitoring/test-stonework.sh
@@ -37,32 +37,32 @@ function check_rv { # parameters: actual rv, expected rv, error message
 
 function check_in_sync {
     echo -n "Checking if StoneWork is in-sync ... "
-    docker-compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
+    docker compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
     check_rv $? 1 "StoneWork is not in-sync"
 }
 
 check_in_sync
 
 echo -n "Checking cross-connect configuration in StoneWork ... "
-[ $(docker-compose exec -T stonework agentctl values 2>/dev/null | grep -c "vpp.l2.xconnect.*CONFIGURED") -eq 2 ]
+[ $(docker compose exec -T stonework agentctl values 2>/dev/null | grep -c "vpp.l2.xconnect.*CONFIGURED") -eq 2 ]
 check_rv $? 0 "Cross-connect configuration missing in StoneWork" 
 
 echo -n "Checking cross-connect in VPP ... "
-[ $(docker-compose exec -T stonework vppctl sh int addr | grep -c "L2 xconnect") -eq 2 ]
+[ $(docker compose exec -T stonework vppctl sh int addr | grep -c "L2 xconnect") -eq 2 ]
 check_rv $? 0 "Cross-connect not configured"
 
-docker-compose exec -T stonework vppctl trace add virtio-input 10
+docker compose exec -T stonework vppctl trace add virtio-input 10
 
 echo -n "Pinging ... "
-docker-compose exec -T tester1 ping -c 1 -w 1 10.10.1.2 >/dev/null
+docker compose exec -T tester1 ping -c 1 -w 1 10.10.1.2 >/dev/null
 check_rv $? 0 "Ping failed"
 
 echo -n "Checking if ping request went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.1.2"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.1.2"
 check_rv $? 0 "Ping request did not go through StoneWork"
 
 echo -n "Checking if ping response went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.2 -> 10.10.1.1"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.2 -> 10.10.1.1"
 check_rv $? 0 "Ping response did not go through StoneWork"
 
 echo "------------------------------------------------"

--- a/examples/testing/010-xconnect/Makefile
+++ b/examples/testing/010-xconnect/Makefile
@@ -24,14 +24,14 @@ dump-logs-ignore-errors:
 exec-test: stop-example-ignore-errors start-example test-stonework stop-example
 
 start-example:
-	@docker-compose up -d
+	@docker compose up -d
 	@../utils.sh waitForAgentConfig stonework 31 20
 
 stop-example:
-	@docker-compose down --remove-orphans -v
+	@docker compose down --remove-orphans -v
 
 stop-example-ignore-errors:
-	@docker-compose down --remove-orphans -v || true
+	@docker compose down --remove-orphans -v || true
 
 test-stonework:
 	@./test-stonework.sh
@@ -43,9 +43,9 @@ dump-logs:
 		echo ===============================================================================;\
 		echo StoneWork logs;\
 		echo ===============================================================================;\
-		docker-compose logs stonework || true;\
+		docker compose logs stonework || true;\
 		echo ===============================================================================;\
 		echo StoneWork running configuration;\
 		echo ===============================================================================;\
-		docker-compose exec -T stonework agentctl config retrieve || true;\
+		docker compose exec -T stonework agentctl config retrieve || true;\
 	) >${LOGFILE} 2>&1"

--- a/examples/testing/010-xconnect/test-stonework.sh
+++ b/examples/testing/010-xconnect/test-stonework.sh
@@ -37,32 +37,32 @@ function check_rv { # parameters: actual rv, expected rv, error message
 
 function check_in_sync {
     echo -n "Checking if StoneWork is in-sync ... "
-    docker-compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
+    docker compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
     check_rv $? 1 "StoneWork is not in-sync"
 }
 
 check_in_sync
 
 echo -n "Checking cross-connect configuration in StoneWork ... "
-[ $(docker-compose exec -T stonework agentctl values 2>/dev/null | grep -c "vpp.l2.xconnect.*CONFIGURED") -eq 2 ]
+[ $(docker compose exec -T stonework agentctl values 2>/dev/null | grep -c "vpp.l2.xconnect.*CONFIGURED") -eq 2 ]
 check_rv $? 0 "Cross-connect configuration missing in StoneWork" 
 
 echo -n "Checking cross-connect in VPP ... "
-[ $(docker-compose exec -T stonework vppctl sh int addr | grep -c "L2 xconnect") -eq 2 ]
+[ $(docker compose exec -T stonework vppctl sh int addr | grep -c "L2 xconnect") -eq 2 ]
 check_rv $? 0 "Cross-connect not configured"
 
-docker-compose exec -T stonework vppctl trace add virtio-input 10
+docker compose exec -T stonework vppctl trace add virtio-input 10
 
 echo -n "Pinging ... "
-docker-compose exec -T tester1 ping -c 1 -w 1 10.10.1.2 >/dev/null
+docker compose exec -T tester1 ping -c 1 -w 1 10.10.1.2 >/dev/null
 check_rv $? 0 "Ping failed"
 
 echo -n "Checking if ping request went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.1.2"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.1.2"
 check_rv $? 0 "Ping request did not go through StoneWork"
 
 echo -n "Checking if ping response went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.2 -> 10.10.1.1"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.2 -> 10.10.1.1"
 check_rv $? 0 "Ping response did not go through StoneWork"
 
 echo "------------------------------------------------"

--- a/examples/testing/020-switch/Makefile
+++ b/examples/testing/020-switch/Makefile
@@ -23,14 +23,14 @@ dump-logs-ignore-errors:
 exec-test: stop-example-ignore-errors start-example test-stonework stop-example
 
 start-example:
-	@docker-compose up -d
+	@docker compose up -d
 	@../utils.sh waitForAgentConfig stonework 32 20
 
 stop-example:
-	@docker-compose down --remove-orphans -v
+	@docker compose down --remove-orphans -v
 
 stop-example-ignore-errors:
-	@docker-compose down --remove-orphans -v || true
+	@docker compose down --remove-orphans -v || true
 
 test-stonework:
 	@./test-stonework.sh
@@ -42,9 +42,9 @@ dump-logs:
 		echo ===============================================================================;\
 		echo StoneWork logs;\
 		echo ===============================================================================;\
-		docker-compose logs stonework || true;\
+		docker compose logs stonework || true;\
 		echo ===============================================================================;\
 		echo StoneWork running configuration;\
 		echo ===============================================================================;\
-		docker-compose exec -T stonework agentctl config retrieve || true;\
+		docker compose exec -T stonework agentctl config retrieve || true;\
 	) >${LOGFILE} 2>&1"

--- a/examples/testing/020-switch/test-stonework.sh
+++ b/examples/testing/020-switch/test-stonework.sh
@@ -37,33 +37,33 @@ function check_rv { # parameters: actual rv, expected rv, error message
 
 function check_in_sync {
     echo -n "Checking if StoneWork is in-sync ... "
-    docker-compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
+    docker compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
     check_rv $? 1 "StoneWork is not in-sync"
 }
 
 check_in_sync
 
 echo -n "Checking bridge configuration in StoneWork ... "
-[ $(docker-compose exec -T stonework agentctl values 2>/dev/null \
+[ $(docker compose exec -T stonework agentctl values 2>/dev/null \
     | grep -c -E "vpp.l2.bridge-domain.*CONFIGURED|vpp/bd/.*CONFIGURED") -eq 3 ]
 check_rv $? 0 "Bridge configuration missing in StoneWork" 
 
 echo -n "Checking bridge in VPP ... "
-[ $(docker-compose exec -T stonework vppctl sh int addr | grep -c "L2 bridge") -eq 2 ]
+[ $(docker compose exec -T stonework vppctl sh int addr | grep -c "L2 bridge") -eq 2 ]
 check_rv $? 0 "Bridge not configured"
 
-docker-compose exec -T stonework vppctl trace add virtio-input 10
+docker compose exec -T stonework vppctl trace add virtio-input 10
 
 echo -n "Pinging ... "
-docker-compose exec -T tester1 ping -c 1 -w 1 10.10.1.2 >/dev/null
+docker compose exec -T tester1 ping -c 1 -w 1 10.10.1.2 >/dev/null
 check_rv $? 0 "Ping failed"
 
 echo -n "Checking if ping request went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.1.2"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.1.2"
 check_rv $? 0 "Ping request did not go through StoneWork"
 
 echo -n "Checking if ping response went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.2 -> 10.10.1.1"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.2 -> 10.10.1.1"
 check_rv $? 0 "Ping response did not go through StoneWork"
 
 echo "------------------------------------------------"

--- a/examples/testing/030-router/Makefile
+++ b/examples/testing/030-router/Makefile
@@ -23,14 +23,14 @@ dump-logs-ignore-errors:
 exec-test: stop-example-ignore-errors start-example test-stonework stop-example
 
 start-example:
-	@docker-compose up -d
+	@docker compose up -d
 	@../utils.sh waitForAgentConfig stonework 46 20
 
 stop-example:
-	@docker-compose down --remove-orphans -v
+	@docker compose down --remove-orphans -v
 
 stop-example-ignore-errors:
-	@docker-compose down --remove-orphans -v || true
+	@docker compose down --remove-orphans -v || true
 
 test-stonework:
 	@./test-stonework.sh
@@ -42,9 +42,9 @@ dump-logs:
 		echo ===============================================================================;\
 		echo StoneWork logs;\
 		echo ===============================================================================;\
-		docker-compose logs stonework || true;\
+		docker compose logs stonework || true;\
 		echo ===============================================================================;\
 		echo StoneWork running configuration;\
 		echo ===============================================================================;\
-		docker-compose exec -T stonework agentctl config retrieve || true;\
+		docker compose exec -T stonework agentctl config retrieve || true;\
 	) >${LOGFILE} 2>&1"

--- a/examples/testing/030-router/test-stonework.sh
+++ b/examples/testing/030-router/test-stonework.sh
@@ -37,33 +37,33 @@ function check_rv { # parameters: actual rv, expected rv, error message
 
 function check_in_sync {
     echo -n "Checking if StoneWork is in-sync ... "
-    docker-compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
+    docker compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
     check_rv $? 1 "StoneWork is not in-sync"
 }
 
 check_in_sync
 
 echo -n "Checking route configuration in StoneWork ... "
-docker-compose exec -T stonework agentctl values 2>/dev/null \
+docker compose exec -T stonework agentctl values 2>/dev/null \
     | grep -q -E "vpp.route.*dst/10.10.3.0/24/gw/10.10.2.2.*CONFIGURED"
 check_rv $? 0 "Route configuration missing in StoneWork" 
 
 echo -n "Checking route in VPP ... "
-docker-compose exec -T stonework vppctl sh ip fib | grep -q "10.10.3.0/24"
+docker compose exec -T stonework vppctl sh ip fib | grep -q "10.10.3.0/24"
 check_rv $? 0 "Route not configured"
 
-docker-compose exec -T stonework vppctl trace add virtio-input 10
+docker compose exec -T stonework vppctl trace add virtio-input 10
 
 echo -n "Pinging ... "
-docker-compose exec -T tester1 ping -c 1 -w 1 10.10.3.2 >/dev/null
+docker compose exec -T tester1 ping -c 1 -w 1 10.10.3.2 >/dev/null
 check_rv $? 0 "Ping failed"
 
 echo -n "Checking if ping request went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.3.2"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.1.1 -> 10.10.3.2"
 check_rv $? 0 "Ping request did not go through StoneWork"
 
 echo -n "Checking if ping response went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.3.2 -> 10.10.1.1"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP: 10.10.3.2 -> 10.10.1.1"
 check_rv $? 0 "Ping response did not go through StoneWork"
 
 echo "------------------------------------------------"

--- a/examples/testing/040-router6/Makefile
+++ b/examples/testing/040-router6/Makefile
@@ -23,14 +23,14 @@ dump-logs-ignore-errors:
 exec-test: stop-example-ignore-errors start-example test-stonework stop-example
 
 start-example:
-	@docker-compose up -d
+	@docker compose up -d
 	@../utils.sh waitForAgentConfig stonework 46 20
 
 stop-example:
-	@docker-compose down --remove-orphans -v
+	@docker compose down --remove-orphans -v
 
 stop-example-ignore-errors:
-	@docker-compose down --remove-orphans -v || true
+	@docker compose down --remove-orphans -v || true
 
 test-stonework:
 	@./test-stonework.sh
@@ -42,9 +42,9 @@ dump-logs:
 		echo ===============================================================================;\
 		echo StoneWork logs;\
 		echo ===============================================================================;\
-		docker-compose logs stonework || true;\
+		docker compose logs stonework || true;\
 		echo ===============================================================================;\
 		echo StoneWork running configuration;\
 		echo ===============================================================================;\
-		docker-compose exec -T stonework agentctl config retrieve || true;\
+		docker compose exec -T stonework agentctl config retrieve || true;\
 	) >${LOGFILE} 2>&1"

--- a/examples/testing/040-router6/README.md
+++ b/examples/testing/040-router6/README.md
@@ -39,7 +39,7 @@ Prerequisities and instructions for running the example can be found in the
 
 **Note:** to use the alternate configuration file, start the example as usual and then run
 ```
-$ docker-compose exec stonework agentctl config update --replace /etc/stonework/config/config-with-arps.yaml
+$ docker compose exec stonework agentctl config update --replace /etc/stonework/config/config-with-arps.yaml
 ```
 
 [readme-testing-examples]: ../README.md

--- a/examples/testing/040-router6/test-stonework.sh
+++ b/examples/testing/040-router6/test-stonework.sh
@@ -37,33 +37,33 @@ function check_rv { # parameters: actual rv, expected rv, error message
 
 function check_in_sync {
     echo -n "Checking if StoneWork is in-sync ... "
-    docker-compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
+    docker compose exec -T stonework agentctl config resync --verbose 2>&1 | grep -qi -E "Executed|error"
     check_rv $? 1 "StoneWork is not in-sync"
 }
 
 check_in_sync
 
 echo -n "Checking route configuration in StoneWork ... "
-docker-compose exec -T stonework agentctl values 2>/dev/null \
+docker compose exec -T stonework agentctl values 2>/dev/null \
     | grep -q -E "vpp.route.*dst/2001:0:0:3::/64/gw/2001:0:0:2::2.*CONFIGURED"
 check_rv $? 0 "Route configuration missing in StoneWork" 
 
 echo -n "Checking route in VPP ... "
-docker-compose exec -T stonework vppctl sh ip6 fib | grep -q "2001:0:0:3::/64"
+docker compose exec -T stonework vppctl sh ip6 fib | grep -q "2001:0:0:3::/64"
 check_rv $? 0 "Route not configured"
 
-docker-compose exec -T stonework vppctl trace add virtio-input 20
+docker compose exec -T stonework vppctl trace add virtio-input 20
 
 echo -n "Pinging ... "
-docker-compose exec -T tester1 ping -c 1 -w 5 2001:0:0:3::2 >/dev/null
+docker compose exec -T tester1 ping -c 1 -w 5 2001:0:0:3::2 >/dev/null
 check_rv $? 0 "Ping failed"
 
 echo -n "Checking if ping request went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP6: 2001:0:0:1::1 -> 2001:0:0:3::2"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP6: 2001:0:0:1::1 -> 2001:0:0:3::2"
 check_rv $? 0 "Ping request did not go through StoneWork"
 
 echo -n "Checking if ping response went through StoneWork ... "
-docker-compose exec -T stonework vppctl show trace | grep -q "ICMP6: 2001:0:0:3::2 -> 2001:0:0:1::1"
+docker compose exec -T stonework vppctl show trace | grep -q "ICMP6: 2001:0:0:3::2 -> 2001:0:0:1::1"
 check_rv $? 0 "Ping response did not go through StoneWork"
 
 echo "------------------------------------------------"

--- a/examples/testing/110-mock-cnf-standalone/Makefile
+++ b/examples/testing/110-mock-cnf-standalone/Makefile
@@ -23,14 +23,14 @@ dump-logs-ignore-errors:
 exec-test: stop-example-ignore-errors start-example test-cnf stop-example
 
 start-example:
-	@docker-compose up -d
+	@docker compose up -d
 	@../utils.sh waitForAgentConfig mockcnf1 49 20
 
 stop-example:
-	@docker-compose down --remove-orphans -v
+	@docker compose down --remove-orphans -v
 
 stop-example-ignore-errors:
-	@docker-compose down --remove-orphans -v || true
+	@docker compose down --remove-orphans -v || true
 
 test-cnf:
 	@./test-cnf.sh
@@ -42,9 +42,9 @@ dump-logs:
 		echo ===============================================================================;\
 		echo Mock CNF logs;\
 		echo ===============================================================================;\
-		docker-compose logs mockcnf1 || true;\
+		docker compose logs mockcnf1 || true;\
 		echo ===============================================================================;\
 		echo Mock CNF running configuration;\
 		echo ===============================================================================;\
-		docker-compose exec -T mockcnf1 agentctl config retrieve || true;\
+		docker compose exec -T mockcnf1 agentctl config retrieve || true;\
 	) >${LOGFILE} 2>&1"

--- a/examples/testing/110-mock-cnf-standalone/README.md
+++ b/examples/testing/110-mock-cnf-standalone/README.md
@@ -24,7 +24,7 @@ Manual Verification
 
 Start the deployment with:
 ```
-$ docker-compose up -d
+$ docker compose up -d
 ```
 
 CNF can be managed through CLI provided by the Ligato framework:
@@ -48,5 +48,5 @@ Automated checks can be found in `test-cnf.sh`.
 
 Bring the deployment down with:
 ```
-$ docker-compose down
+$ docker compose down
 ```

--- a/examples/testing/110-mock-cnf-standalone/test-cnf.sh
+++ b/examples/testing/110-mock-cnf-standalone/test-cnf.sh
@@ -37,7 +37,7 @@ function check_rv { # parameters: actual rv, expected rv, error message
 
 function check_in_sync {
     echo -n "Checking if mock CNF 1 is in-sync ... "
-    docker-compose exec -T mockcnf1 curl -X POST localhost:9191/scheduler/downstream-resync?verbose=1 2>&1 \
+    docker compose exec -T mockcnf1 curl -X POST localhost:9191/scheduler/downstream-resync?verbose=1 2>&1 \
         | grep -qi -E "Executed|error"
     check_rv $? 1 "Mock CNF 1 is not in-sync"
 }
@@ -45,18 +45,18 @@ function check_in_sync {
 check_in_sync
 
 # test JSON schema
-schema=$(docker-compose exec -T mockcnf1 curl localhost:9191/info/configuration/jsonschema 2>/dev/null)
+schema=$(docker compose exec -T mockcnf1 curl localhost:9191/info/configuration/jsonschema 2>/dev/null)
 
 echo -n "Checking mock CNF 1 model in JSON schema ... "
 echo $schema | grep -q '"mock1Config": {'
 check_rv $? 0 "Mock CNF 1 model is missing in JSON schema"
 
 echo -n "Checking route in mock CNF 1 ... "
-docker-compose exec -T mockcnf1 ip route show table 1 | grep -q "7.7.7.7 dev tap"
+docker compose exec -T mockcnf1 ip route show table 1 | grep -q "7.7.7.7 dev tap"
 check_rv $? 0 "Mock CNF 1 has not configured route"
 
 echo -n "Updating config ... "
-docker-compose exec -T mockcnf1 agentctl config update --replace /etc/mockcnf/config/running-config.yaml >/dev/null 2>&1
+docker compose exec -T mockcnf1 agentctl config update --replace /etc/mockcnf/config/running-config.yaml >/dev/null 2>&1
 check_rv $? 0 "Config update failed"
 
 ../utils.sh waitForAgentConfig mockcnf1 72 10 # mock CNFs make changes asynchronously
@@ -64,7 +64,7 @@ check_rv $? 0 "Config update failed"
 check_in_sync
 
 echo -n "Checking re-configured route in mock CNF 1 ... "
-docker-compose exec -T mockcnf1 ip route show table 2 | grep -q "7.7.7.7 dev tap"
+docker compose exec -T mockcnf1 ip route show table 2 | grep -q "7.7.7.7 dev tap"
 check_rv $? 0 "Mock CNF 1 has not re-configured route"
 
 echo "------------------------------------------------"

--- a/examples/testing/README.md
+++ b/examples/testing/README.md
@@ -57,11 +57,11 @@ Running The Examples: The Manual Way
 
 Navigate to the directory of the chosen example and start the deployment with
 ```
-$ docker-compose up -d
+$ docker compose up -d
 ```
 or using a custom StoneWork image:
 ```
-STONEWORK_IMAGE=stonework:<version> docker-compose up -d
+STONEWORK_IMAGE=stonework:<version> docker compose up -d
 ```
 This command starts the example topology (it is defined in `docker-compose.yaml`).
 
@@ -77,15 +77,15 @@ $ agentctl <command>
 ```
 Otherwise, you can run
 ```
-$ docker-compose exec stonework agentctl <command>
+$ docker compose exec stonework agentctl <command>
 ```
 For more information about `agentctl` commands, see [Getting started example][getting-started].
 
 You can explore any container in the topology using
 ```
-$ docker-compose exec -it <container-name> bash
+$ docker compose exec -it <container-name> bash
 $ # Example:
-$ docker-compose exec -it stonework bash
+$ docker compose exec -it stonework bash
 ```
 
 **Note**: Automated tests for StoneWork can be found in `test-stonework.sh`.
@@ -101,14 +101,14 @@ $ ./test-stonework.sh
 
 To study StoneWork logs, run
 ```
-$ docker-compose logs stonework
+$ docker compose logs stonework
 ```
 
 ### Stop The Example
 
 When you are done, bring the deployment down with
 ```
-$ docker-compose down
+$ docker compose down
 ```
 
 [getting-started]: ../getting-started/README.md

--- a/examples/testing/utils.sh
+++ b/examples/testing/utils.sh
@@ -22,7 +22,7 @@
 # - timeout, in seconds
 function waitForAgentConfig {
 	SLEPT=0
-	while ! [ $(docker-compose exec -T $1 agentctl values 2>/dev/null | grep -c -E "CONFIGURED|obtained") -ge $2 ]
+	while ! [ $(docker compose exec -T $1 agentctl values 2>/dev/null | grep -c -E "CONFIGURED|obtained") -ge $2 ]
 	do
 		sleep 1
 		SLEPT=$((SLEPT+1))

--- a/experiments/sr-mpls/Makefile
+++ b/experiments/sr-mpls/Makefile
@@ -15,8 +15,8 @@
 # limitations under the License.
 
 start-topology:
-	docker-compose up -d
+	docker compose up -d
 
 stop-topology:
-	docker-compose down
+	docker compose down
 


### PR DESCRIPTION
This PR replaces all occurences of standalone `docker-compose` (Compose V1) with compose plugin `docker compose` (Compose V2). As from July 2023 Docker Compose V1 stopped receiving updates ([more info here](https://docs.docker.com/compose/migrate/)). Moreover `swctl` already used V2 so this change unifies the usage of Compose across the codebase.
Mentions of Docker/Docker Compose in docs are also updated.

Signed-off-by: Peter Motičák [peter.moticak@pantheon.tech](mailto:peter.moticak@pantheon.tech)