### PR TITLE
Add central command executor

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -62,6 +62,7 @@ func WithHTTPTLS(cert, key, ca string, skipVerify bool) Option {
 // StoneWork.
 type API interface {
 	GetComponents() ([]Component, error)
+	GetHost() string
 }
 
 // Client implements API interface.
@@ -127,6 +128,10 @@ func NewClient(opts ...Option) (*Client, error) {
 	}
 
 	return c, nil
+}
+
+func (c *Client) GetHost() string {
+	return c.host
 }
 
 func (c *Client) DockerClient() *docker.Client {

--- a/cmd/swctl/cmd_config.go
+++ b/cmd/swctl/cmd_config.go
@@ -11,7 +11,7 @@ import (
 )
 
 // TODO:
-// - run the agentctl with the default host set to stonework (using the -H or running inside stonework image)
+// - decide when to run agentctl inside docker container or outside of docker container
 
 type ConfigCmdOptions struct {
 	ShowInternal bool
@@ -48,11 +48,12 @@ func runConfigCmd(cli Cli, opts ConfigCmdOptions) error {
 		args = append(args, hideInternalFlag)
 	}
 
-	out, err := cli.Exec("agentctl config", args)
+	stdout, stderr, err := cli.Exec("agentctl config", args)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(cli.Out(), out)
+	fmt.Fprintln(cli.Err(), stderr)
+	fmt.Fprintln(cli.Out(), stdout)
 	return nil
 }

--- a/cmd/swctl/cmd_deploy.go
+++ b/cmd/swctl/cmd_deploy.go
@@ -57,11 +57,12 @@ func newDeploymentUp(cli Cli) *cobra.Command {
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := cli.Exec("docker compose up", args)
+			stdout, stderr, err := cli.Exec("docker compose up", args)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cli.Out(), out)
+			fmt.Fprintln(cli.Out(), stdout)
+			fmt.Fprintln(cli.Err(), stderr)
 			return nil
 		},
 	}
@@ -75,11 +76,12 @@ func newDeploymentDown(cli Cli) *cobra.Command {
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := cli.Exec("docker compose down", args)
+			stdout, stderr, err := cli.Exec("docker compose down", args)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cli.Out(), out)
+			fmt.Fprintln(cli.Out(), stdout)
+			fmt.Fprintln(cli.Err(), stderr)
 			return nil
 		},
 	}
@@ -93,11 +95,12 @@ func newDeploymentConfig(cli Cli) *cobra.Command {
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := cli.Exec("docker compose convert", args)
+			stdout, stderr, err := cli.Exec("docker compose convert", args)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cli.Out(), out)
+			fmt.Fprintln(cli.Out(), stdout)
+			fmt.Fprintln(cli.Err(), stderr)
 			return nil
 		},
 	}
@@ -111,11 +114,12 @@ func newDeploymentInfo(cli Cli) *cobra.Command {
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := cli.Exec("docker compose ps", args)
+			stdout, stderr, err := cli.Exec("docker compose ps", args)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cli.Out(), out)
+			fmt.Fprintln(cli.Out(), stdout)
+			fmt.Fprintln(cli.Err(), stderr)
 			return nil
 		},
 	}
@@ -129,11 +133,12 @@ func newDeploymentImages(cli Cli) *cobra.Command {
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := cli.Exec("docker compose images", args)
+			stdout, stderr, err := cli.Exec("docker compose images", args)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cli.Out(), out)
+			fmt.Fprintln(cli.Out(), stdout)
+			fmt.Fprintln(cli.Err(), stderr)
 			return nil
 		},
 	}
@@ -147,11 +152,12 @@ func newDeploymentServices(cli Cli) *cobra.Command {
 		Args:               cobra.ArbitraryArgs,
 		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			out, err := cli.Exec("docker compose ps --services", args)
+			stdout, stderr, err := cli.Exec("docker compose ps --services", args)
 			if err != nil {
 				return err
 			}
-			fmt.Fprintln(cli.Out(), out)
+			fmt.Fprintln(cli.Out(), stdout)
+			fmt.Fprintln(cli.Err(), stderr)
 			return nil
 		},
 	}

--- a/cmd/swctl/cmd_status.go
+++ b/cmd/swctl/cmd_status.go
@@ -86,14 +86,15 @@ func runStatusCmd(cli Cli, opts StatusOptions) error {
 			if sn, ok := compo.GetMetadata()["containerServiceName"]; ok {
 				cmd := fmt.Sprintf("vpp-probe --env=%s --query label=%s=%s discover", defaultVppProbeEnv, client.DockerComposeServiceLabel, sn)
 				formatArg := fmt.Sprintf("--format=%s", opts.Format)
-				out, err := cli.Exec(cmd, []string{formatArg})
+				stdout, stderr, err := cli.Exec(cmd, []string{formatArg})
 				if err != nil {
 					if ee, ok := err.(*exec.ExitError); ok {
 						logrus.Tracef("vpp-probe discover failed for service %s with error: %v: %s", sn, ee.String(), ee.Stderr)
 						continue
 					}
 				}
-				fmt.Fprintln(cli.Out(), out)
+				fmt.Fprintln(cli.Out(), stdout)
+				fmt.Fprintln(cli.Err(), stderr)
 			}
 		}
 		return nil

--- a/cmd/swctl/cmd_support.go
+++ b/cmd/swctl/cmd_support.go
@@ -27,12 +27,12 @@ func runSupportCmd(cli Cli, opts SupportCmdOptions, args []string) error {
 
 	// TODO: add stonework/CNF related support data to the export
 
-	out, err := cli.Exec("agentctl report", args)
+	stdout, stderr, err := cli.Exec("agentctl report", args)
 	if err != nil {
 		return err
 	}
 
-	fmt.Fprintln(cli.Out(), out)
-
+	fmt.Fprintln(cli.Out(), stdout)
+	fmt.Fprintln(cli.Err(), stderr)
 	return nil
 }

--- a/cmd/swctl/cmd_trace.go
+++ b/cmd/swctl/cmd_trace.go
@@ -31,13 +31,14 @@ func runTraceCmd(cli Cli, opts TraceCmdOptions) error {
 	// TODO: improve usage of trace command
 	// - automatically use ping as default command
 	// - consider selecting IP and source network namespace automatically
-	// - cibsuder allowing users to simply select component names for ping src/dst
+	// - consider allowing users to simply select component names for ping src/dst
 
-	out, err := cli.Exec(fmt.Sprintf("vpp-probe --env=%s trace", defaultVppProbeEnv), args)
+	stdout, stderr, err := cli.Exec(fmt.Sprintf("vpp-probe --env=%s trace", defaultVppProbeEnv), args)
 	if err != nil {
 		return err
 	}
-	fmt.Fprintln(cli.Out(), out)
+	fmt.Fprintln(cli.Out(), stdout)
+	fmt.Fprintln(cli.Err(), stderr)
 
 	return nil
 }

--- a/cmd/swctl/exec.go
+++ b/cmd/swctl/exec.go
@@ -5,54 +5,149 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/gookit/color"
 	"github.com/sirupsen/logrus"
 )
 
-func execCmd(cmd string, args []string) (string, error) {
-	cmdParts := strings.Split(cmd, " ")
-	command := cmdParts[0]
+type externalExe string
 
-	var commandArgs []string
-	if len(cmdParts) > 1 {
-		for _, part := range cmdParts[1:] {
-			if strings.TrimSpace(part) == "" {
-				continue
-			}
-			commandArgs = append(commandArgs, part)
+// known external programs that swctl can execute
+const (
+	cmdDocker   externalExe = "docker"
+	cmdVppProbe externalExe = "vpp-probe"
+	cmdAgentCtl externalExe = "agentctl"
+)
+
+type externalCmd struct {
+	cli   *CLI
+	exe   externalExe
+	name  string
+	args  []string
+	env   []string
+	color bool
+}
+
+func newExternalCmd(cmd externalExe, args []string, cli *CLI, swctlOpts GlobalOptions) *externalCmd {
+	ecmd := &externalCmd{
+		exe:   cmd,
+		name:  string(cmd),
+		cli:   cli,
+		color: swctlOpts.Color != "never" && cli.Out().IsTerminal(),
+	}
+	ecmd.setDebugArg(swctlOpts.Debug)
+	ecmd.setLogLevelArg(logrus.GetLevel())
+	ecmd.setColorEnv()
+	ecmd.setMiscFlags()
+	ecmd.args = append(ecmd.args, args...)
+	return ecmd
+}
+
+func (ec *externalCmd) prependArg(arg string, val string, aliases ...string) {
+	if !hasAnyPrefix(ec.args, arg) && !hasAnyPrefix(ec.args, aliases...) {
+		if val == "" {
+			ec.args = append([]string{arg}, ec.args...)
+		} else {
+			ec.args = append([]string{fmt.Sprintf("%s=%s", arg, val)}, ec.args...)
 		}
 	}
-	commandArgs = append(commandArgs, args...)
+}
 
-	c := exec.Command(command, commandArgs...)
+func (ec *externalCmd) setDebugArg(debug bool) {
+	switch ec.exe {
+	case cmdAgentCtl, cmdDocker, cmdVppProbe:
+		if debug {
+			ec.prependArg("--debug", "", "-D")
+		}
+	}
+}
 
+func (ec *externalCmd) setLogLevelArg(loglvl logrus.Level) {
+	if loglvl < logrus.FatalLevel {
+		loglvl = logrus.FatalLevel
+	}
+	if loglvl > logrus.DebugLevel {
+		loglvl = logrus.DebugLevel
+	}
+	switch ec.exe {
+	case cmdAgentCtl, cmdDocker:
+		ec.prependArg("--log-level", loglvl.String(), "-l")
+	case cmdVppProbe:
+		ec.prependArg("--loglevel", loglvl.String(), "-L")
+	}
+}
+
+// https://no-color.org/
+func (ec *externalCmd) setColorEnv() {
+	if !ec.color {
+		ec.env = append(ec.env, "NO_COLOR=1")
+	}
+}
+
+func (ec *externalCmd) setMiscFlags() {
+	switch ec.exe {
+	case cmdVppProbe:
+		if ec.color {
+			ec.prependArg("--color", "always")
+		}
+		if ec.cli.vppProbePath != "" {
+			ec.name = ec.cli.vppProbePath
+		}
+	case cmdAgentCtl:
+		ec.prependArg("--host", ec.cli.client.GetHost(), "-H")
+	}
+}
+
+type ExecResult struct {
+	Took   time.Duration
+	Status int
+	Stdout string
+	Stderr string
+}
+
+func (ec *externalCmd) exec() (*ExecResult, error) {
 	var stdout, stderr bytes.Buffer
-	//c.Stdin = os.Stdin
-	c.Stdout = &stdout
-	c.Stderr = &stderr
-	//env := os.Environ()
-	//c.Env = env
+	cmd := exec.Command(ec.name, ec.args...)
+	cmd.Env = ec.env
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
 
-	logrus.Tracef("[%s] %q", color.Gray.Sprint("EXEC"), c.String())
+	now := time.Now()
+	logrus.Tracef("[%s] %q", color.Gray.Sprint("EXEC"), cmd.String())
+	err := cmd.Run()
+	took := time.Since(now)
+	l := logrus.WithField("took", took.Round(1*time.Millisecond).String())
 
-	t := time.Now()
-
-	err := c.Run()
-	out := strings.TrimRight(stdout.String(), "\n")
-	took := time.Since(t).Seconds()
-	l := logrus.WithField("took", fmt.Sprintf("%.3f", took))
+	var execRes ExecResult
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {
-			ee.Stderr = stderr.Bytes()
+			l.Tracef("[%s] %q (%v)\n%s\n", color.Red.Sprint("ERR"), cmd.Args, color.Red.Sprint(err), color.LightRed.Sprint(stderr.String()))
+			execRes.Status = ee.ProcessState.Sys().(syscall.WaitStatus).ExitStatus()
+		} else {
+			return nil, err
 		}
-
-		l.Tracef("[%s] %q (%v)\n%s\n", color.Red.Sprint("ERR"), c.Args, color.Red.Sprint(err), color.LightRed.Sprint(stderr.String()))
-		return stdout.String(), err
-	} else {
-		l.Tracef("[%s] %q\n%s\n", color.Green.Sprint("OK"), c.Args, color.FgGray.Sprint(out))
 	}
 
-	return stdout.String(), nil
+	execRes.Took = took
+	execRes.Stdout = strings.TrimRight(stdout.String(), "\n")
+	execRes.Stderr = strings.TrimRight(stderr.String(), "\n")
+	l.Tracef("[%s] %q\n%s\n", color.Green.Sprint("OK"), cmd.Args, color.FgGray.Sprint(execRes.Stdout))
+	return &execRes, nil
+}
+
+func anyPrefixIndex(elems []string, prefixes ...string) int {
+	for i, elem := range elems {
+		for _, pref := range prefixes {
+			if strings.HasPrefix(elem, pref) {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+func hasAnyPrefix(elems []string, prefixes ...string) bool {
+	return anyPrefixIndex(elems, prefixes...) >= 0
 }


### PR DESCRIPTION
Purpose of central executor is to mainly automatically set certain flags (if not set explicitly) of external commands to match those of `swctl`.

Signed-off-by: Peter Motičák [peter.moticak@pantheon.tech](mailto:peter.moticak@pantheon.tech)