### PR TITLE
Merge global swctl flags into one structure

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -121,7 +121,7 @@ func NewClient(opts ...Option) (*Client, error) {
 		}
 	}
 	if c.host == "" {
-		logrus.Warnf("could not find StoneWork service management IP address falling back to: %s", FallbackHost)
+		logrus.Debugf("could not find StoneWork service management IP address falling back to: %s", FallbackHost)
 		c.host = FallbackHost
 	} else {
 		logrus.Debugf("found StoneWork service management IP address: %s", c.host)

--- a/cmd/swctl/cmd.go
+++ b/cmd/swctl/cmd.go
@@ -23,27 +23,21 @@ const logo = `
 // NewRootCmd returns new root command
 func NewRootCmd(cli Cli) *cobra.Command {
 	var (
-		opts Options
+		glob GlobalOptions
 	)
 	cmd := &cobra.Command{
 		Use:           "swctl [options] [command]",
-		Short:         "swctl is CLI app to manage StoneWork and its components",
+		Short:         "swctl is CLI tool to manage StoneWork and its components",
 		Long:          color.Sprintf(logo, version.Short(), version.BuildTime(), version.BuiltBy()),
 		Version:       version.String(),
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			InitGlobalOptions(cli, &glob)
-
-			logrus.Tracef("global options: %+v", glob)
-
-			err := cli.Initialize(opts)
+			err := cli.Initialize(&glob)
 			if err != nil {
 				return err
 			}
-
-			logrus.Tracef("initialized CLI options: %+v", opts)
-
+			logrus.Tracef("initialized global options: %+v", glob)
 			return nil
 		},
 		TraverseChildren:  true,
@@ -57,7 +51,6 @@ func NewRootCmd(cli Cli) *cobra.Command {
 	cmd.Flags().SortFlags = false
 	cmd.PersistentFlags().SortFlags = false
 
-	opts.InstallFlags(cmd.PersistentFlags())
 	glob.InstallFlags(cmd.PersistentFlags())
 
 	cmd.InitDefaultVersionFlag()

--- a/cmd/swctl/options.go
+++ b/cmd/swctl/options.go
@@ -16,14 +16,14 @@ const (
 	EnvVarVppProbeNoDownload = "SWCTL_VPP_PROBE_NO_DOWNLOAD"
 )
 
-var (
-	glob GlobalOptions
-)
-
 type GlobalOptions struct {
 	Debug    bool
 	LogLevel string
 	Color    string
+
+	ComposeFiles []string
+	EntityFiles  []string
+
 	// TODO: support config file
 	// Config string
 }
@@ -79,17 +79,10 @@ func (glob *GlobalOptions) InstallFlags(flags *pflag.FlagSet) {
 	flags.BoolVarP(&glob.Debug, "debug", "D", false, "Enable debug mode")
 	flags.StringVarP(&glob.LogLevel, "log-level", "L", "", "Set logging level")
 	flags.StringVar(&glob.Color, "color", "", "Color mode; auto/always/never")
-}
 
-type Options struct {
-	ComposeFiles []string
-	EntityFiles  []string
-}
-
-func (opts *Options) InstallFlags(flags *pflag.FlagSet) {
-	flags.StringSliceVar(&opts.ComposeFiles, "composefile", nil, "Docker Compose configuration files")
+	flags.StringSliceVar(&glob.ComposeFiles, "composefile", nil, "Docker Compose configuration files")
 	must(cobra.MarkFlagFilename(flags, "composefile", "yaml", "yml"))
-	flags.StringSliceVar(&opts.EntityFiles, "entityfile", nil, "Entity configuration files")
+	flags.StringSliceVar(&glob.EntityFiles, "entityfile", nil, "Entity configuration files")
 	must(cobra.MarkFlagFilename(flags, "entityfile", "yaml", "yml"))
 }
 


### PR DESCRIPTION
Also pass `--composefile` swctl flag to Docker when executing `docker compose`.

Note: perhaps `GlobalOptions` struct and related method/field in `CLI` struct could be renamed to something like `GlobalFlags` to better distinguish it from functional `CliOptions`?

Signed-off-by: Peter Motičák [peter.moticak@pantheon.tech](mailto:peter.moticak@pantheon.tech)