### PR TITLE
upgraded docker login action to prevent problems with soon-to-be deprecated github workflow commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         run: docker images
 
       - name: "Login to ghcr.io registry"
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
This PR fixes warnings from the release action(https://github.com/PANTHEONtech/StoneWork/actions/runs/6313188882):
```
release
The following actions uses node12 which is deprecated and will be forced to run on node16: docker/login-action@v1. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/
release
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
release
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
release
The `save-state` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```
These warnings would not be warnings anymore and release job would be already broken if github would not postpone the deprecation (https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

We are not directly using those commands, but the action that we use for docker login is using it. This tool has already fixed the issues (https://github.com/docker/login-action/pull/158 , @actions/core version bump in https://github.com/docker/login-action/releases/tag/v2.1.0). So using 2.1.0 would probably fix it, but i used the latest 3.0.0.

**Testing:**
Testing is complicated as it needs to have the change already pushed so that the changed github action can be triggered by some event. Also docker image repository is needed as docker login is involved.
I did testing in my fork. I applied this PR to main. Changed the github action to do only docker login and used my personal github packages as docker image repo (see changes in https://github.com/fgschwan/StoneWork/tree/fix-release-job-warnings, + also created temporal github token for packages access and put token string to repo secret variable available to action). After that i created separate branch (https://github.com/fgschwan/StoneWork/tree/fix-release-job-warnings-test) just to make test commit that trigger the job and i can see that docker login passes successfully.
I didn't want to pollute this repo with such testing, therefore i did the testing in my fork. Anyone can repeat this to verify the change.
