### PR TITLE
swctl: redirect output from command 'manage <Entity> create' to file

### DIFF
--- a/cmd/swctl/app/cmd_manage.go
+++ b/cmd/swctl/app/cmd_manage.go
@@ -64,7 +64,7 @@ type ManageOptions struct {
 	Vars        map[string]string
 	ShowConfig  bool
 	Interactive bool
-	File        string
+	OutputFile  string
 }
 
 func (opts *ManageOptions) InstallFlags(flagset *pflag.FlagSet) {
@@ -77,7 +77,8 @@ func (opts *ManageOptions) InstallFlags(flagset *pflag.FlagSet) {
 	flagset.BoolVar(&opts.ShowConfig, "show-config", false, "Print config for entity detail")
 	flagset.BoolVarP(&opts.Interactive, "interactive", "i", false, "Enable interactive mode")
 	flagset.StringToStringVar(&opts.Vars, "var", nil, "Override values for variables (--var VAR_NAME=value)")
-	flagset.StringVar(&opts.File, "file", "", "Define the output file name (default: <entityName>.yaml)")
+	flagset.StringVar(&opts.OutputFile, "output-file", "", `Define the output file name. Format from format flag will be used as suffix
+	 (default: <entityName>.<actual format suffix>)`)
 }
 
 func NewManageCmd(cli Cli) *cobra.Command {
@@ -379,13 +380,11 @@ func runManageCmd(cli Cli, opts ManageOptions, args []string) error {
 	var fileName string
 	var writer io.Writer
 
-	if strings.HasSuffix(opts.File, opts.Format) {
-		fileName = opts.File
-	} else {
+	if opts.OutputFile == "" {
 		fileName = fmt.Sprintf("%s.%s", entityName, opts.Format)
-		if opts.File != "" {
-			logrus.Warnf("Defined output file name is not in required format. Naming %s will be used.", fileName)
-		}
+	} else {
+		outputFilePrefix := strings.Split(opts.OutputFile, ".")
+		fileName = fmt.Sprintf("%s.%s", outputFilePrefix[0], opts.Format)
 	}
 
 	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0666)
@@ -393,6 +392,7 @@ func runManageCmd(cli Cli, opts ManageOptions, args []string) error {
 		logrus.Warnln(fmt.Errorf("%s : the configuration file will be printed to stdout", err))
 		writer = cli.Out()
 	} else {
+		defer file.Close()
 		writer = file
 	}
 

--- a/cmd/swctl/app/cmd_manage.go
+++ b/cmd/swctl/app/cmd_manage.go
@@ -377,17 +377,25 @@ func runManageCmd(cli Cli, opts ManageOptions, args []string) error {
 		opts.Format = "yaml"
 	}
 
-	var fileName string
+	var filePath string
 	var writer io.Writer
 
 	if opts.OutputFile == "" {
-		fileName = fmt.Sprintf("%s.%s", entityName, opts.Format)
+		filePath = fmt.Sprintf("%s.%s", entityName, opts.Format)
 	} else {
-		outputFilePrefix := strings.Split(opts.OutputFile, ".")
-		fileName = fmt.Sprintf("%s.%s", outputFilePrefix[0], opts.Format)
+		dir := filepath.Dir(opts.OutputFile)
+		base := filepath.Base(opts.OutputFile)
+		err = os.MkdirAll(dir, 0777)
+		if err != nil {
+			return err
+		}
+
+		outputFilePrefix := strings.Split(base, ".")
+		filePath = fmt.Sprintf("%s.%s", outputFilePrefix[0], opts.Format)
+		filePath = filepath.Join(dir, filePath)
 	}
 
-	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0666)
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		logrus.Warnln(fmt.Errorf("%s : the configuration file will be printed to stdout", err))
 		writer = cli.Out()


### PR DESCRIPTION
Currently configuration generated by the manage command is printed into console making it cumbersome to copy paste it into desired file (especially in --interactive mode as user cannot just redirect it > into a file).


default name of file is generated by entity name and selected format. It can be overriden by --file flag where suffix must be the same as selected format