### PR TITLE
swctl: use help from agentctl 

### DIFF
--- a/cmd/swctl/app/cmd_config.go
+++ b/cmd/swctl/app/cmd_config.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -20,6 +21,7 @@ type ConfigCmdOptions struct {
 
 func (opts *ConfigCmdOptions) InstallFlags(flagset *pflag.FlagSet) {
 	flagset.BoolVar(&opts.ShowInternal, "show-internal", false, "Add Stonework internal configuration to output if possible")
+
 }
 
 func NewConfigCmd(cli Cli) *cobra.Command {
@@ -27,21 +29,47 @@ func NewConfigCmd(cli Cli) *cobra.Command {
 		opts ConfigCmdOptions
 	)
 	cmd := &cobra.Command{
-		Use:   "config [flags] ACTION",
-		Short: "Manage config of StoneWork components",
-		Args:  cobra.ArbitraryArgs,
-		// DisableFlagParsing: true,
+		Use:                "config [flags] ACTION",
+		Short:              "Manage config of StoneWork components",
+		Args:               cobra.ArbitraryArgs,
+		DisableFlagParsing: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts.Args = args
-			return runConfigCmd(cli, opts)
+			return runConfigCmd(cli, opts, cmd)
 		},
 	}
 	opts.InstallFlags(cmd.PersistentFlags())
 	return cmd
 }
 
-func runConfigCmd(cli Cli, opts ConfigCmdOptions) error {
+type temporaryFlag struct {
+	// full name flag
+	key string
+	// full line
+	value string
+}
+
+func runConfigCmd(cli Cli, opts ConfigCmdOptions, cmd *cobra.Command) error {
+	var ParsedFlags []temporaryFlag
 	args := opts.Args
+
+	if slices.Contains(args, "--help") || slices.Contains(args, "-h") {
+		// add Local flags to stdout of agentctl
+		stdout, stderr, shouldReturn, returnValue := mergeHelpers(cmd, ParsedFlags, cli, args)
+		if shouldReturn {
+			return returnValue
+		}
+
+		fmt.Fprintln(cli.Err(), stderr)
+		fmt.Fprintln(cli.Out(), stdout)
+		return nil
+	}
+
+	if slices.Contains(args, "--show-internal") {
+		opts.ShowInternal = true
+		idx := slices.Index[string](args, "--show-internal")
+		args = append(args[:idx], args[idx+1:]...)
+	}
 
 	if slices.Contains(args, "get") && !opts.ShowInternal {
 		hideInternalFlag := "--labels=\"!" + puntmgr.InternalConfigLabelKey + "=" + puntmgr.InternalConfigLabelValue + "\""
@@ -56,4 +84,35 @@ func runConfigCmd(cli Cli, opts ConfigCmdOptions) error {
 	fmt.Fprintln(cli.Err(), stderr)
 	fmt.Fprintln(cli.Out(), stdout)
 	return nil
+}
+
+func mergeHelpers(cmd *cobra.Command, ParsedFlags []temporaryFlag, cli Cli, args []string) (string, string, bool, error) {
+	flags := cmd.LocalFlags()
+	bufb := flags.FlagUsages()
+
+	for _, v := range strings.Split(bufb, "\n") {
+		var flag temporaryFlag
+		ls := strings.ReplaceAll(v, ",", " ")
+		tokenized := strings.Fields(ls)
+		for _, token := range tokenized {
+			if strings.Contains(token, "--") {
+				flag.key = token
+				flag.value = v
+				break
+			}
+		}
+		ParsedFlags = append(ParsedFlags, flag)
+	}
+	_ = ParsedFlags
+
+	stdout, stderr, err := cli.Exec("agentctl config", args)
+	if err != nil {
+		return "", "", true, err
+	}
+
+	globalsIndex := strings.Index(stdout, "GLOBALS:")
+	if globalsIndex != -1 {
+		stdout = stdout[:globalsIndex] + fmt.Sprintf("Flags:\n%s", bufb) + stdout[globalsIndex:]
+	}
+	return stdout, stderr, false, nil
 }

--- a/cmd/swctl/app/cmd_manage.go
+++ b/cmd/swctl/app/cmd_manage.go
@@ -64,7 +64,7 @@ type ManageOptions struct {
 	Vars        map[string]string
 	ShowConfig  bool
 	Interactive bool
-	File        string
+	OutputFile  string
 }
 
 func (opts *ManageOptions) InstallFlags(flagset *pflag.FlagSet) {
@@ -77,7 +77,8 @@ func (opts *ManageOptions) InstallFlags(flagset *pflag.FlagSet) {
 	flagset.BoolVar(&opts.ShowConfig, "show-config", false, "Print config for entity detail")
 	flagset.BoolVarP(&opts.Interactive, "interactive", "i", false, "Enable interactive mode")
 	flagset.StringToStringVar(&opts.Vars, "var", nil, "Override values for variables (--var VAR_NAME=value)")
-	flagset.StringVar(&opts.File, "file", "", "Define the output file name (default: <entityName>.yaml)")
+	flagset.StringVar(&opts.OutputFile, "output-file", "", `Define the output file name. Format from format flag will be used as suffix
+	 (default: <entityName>.<actual format suffix>)`)
 }
 
 func NewManageCmd(cli Cli) *cobra.Command {
@@ -379,13 +380,11 @@ func runManageCmd(cli Cli, opts ManageOptions, args []string) error {
 	var fileName string
 	var writer io.Writer
 
-	if strings.HasSuffix(opts.File, opts.Format) {
-		fileName = opts.File
-	} else {
+	if opts.OutputFile == "" {
 		fileName = fmt.Sprintf("%s.%s", entityName, opts.Format)
-		if opts.File != "" {
-			logrus.Warnf("Defined output file name is not in required format. Naming %s will be used.", fileName)
-		}
+	} else {
+		outputFilePrefix := strings.Split(opts.OutputFile, ".")
+		fileName = fmt.Sprintf("%s.%s", outputFilePrefix[0], opts.Format)
 	}
 
 	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0666)
@@ -393,6 +392,7 @@ func runManageCmd(cli Cli, opts ManageOptions, args []string) error {
 		logrus.Warnln(fmt.Errorf("%s : the configuration file will be printed to stdout", err))
 		writer = cli.Out()
 	} else {
+		defer file.Close()
 		writer = file
 	}
 

--- a/cmd/swctl/app/cmd_manage.go
+++ b/cmd/swctl/app/cmd_manage.go
@@ -377,17 +377,25 @@ func runManageCmd(cli Cli, opts ManageOptions, args []string) error {
 		opts.Format = "yaml"
 	}
 
-	var fileName string
+	var filePath string
 	var writer io.Writer
 
 	if opts.OutputFile == "" {
-		fileName = fmt.Sprintf("%s.%s", entityName, opts.Format)
+		filePath = fmt.Sprintf("%s.%s", entityName, opts.Format)
 	} else {
-		outputFilePrefix := strings.Split(opts.OutputFile, ".")
-		fileName = fmt.Sprintf("%s.%s", outputFilePrefix[0], opts.Format)
+		dir := filepath.Dir(opts.OutputFile)
+		base := filepath.Base(opts.OutputFile)
+		err = os.MkdirAll(dir, 0777)
+		if err != nil {
+			return err
+		}
+
+		outputFilePrefix := strings.Split(base, ".")
+		filePath = fmt.Sprintf("%s.%s", outputFilePrefix[0], opts.Format)
+		filePath = filepath.Join(dir, filePath)
 	}
 
-	file, err := os.OpenFile(fileName, os.O_WRONLY|os.O_CREATE, 0666)
+	file, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE, 0666)
 	if err != nil {
 		logrus.Warnln(fmt.Errorf("%s : the configuration file will be printed to stdout", err))
 		writer = cli.Out()


### PR DESCRIPTION
swctl is wrapping agentctl but can't pass flags to it.
This PR is changing swctl config flags to arguments and inside of function is deciding if flags belongs to swctl or agentctl.
+ in case of help flag both flagset are merged to one help.