### PR TITLE
swctl: added support for using go template range loops in entity configs

### DIFF
--- a/cmd/swctl/app/entity.go
+++ b/cmd/swctl/app/entity.go
@@ -3,6 +3,7 @@ package app
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/buildkite/interpolate"
 	"github.com/sirupsen/logrus"
@@ -10,7 +11,8 @@ import (
 )
 
 const (
-	defaultEntityFile = "entities.yaml"
+	defaultEntityFile      = "entities.yaml"
+	NonInputVariablePrefix = "noninput_" // used for go templating variables that are not Entity input variables, i.e. temporal range loop variable
 )
 
 // EntityFile is a file containing entities loaded during initialization.
@@ -188,7 +190,8 @@ func validateEntity(entity *Entity) error {
 			}
 			continue
 		}
-		if _, ok := vars[ident]; !ok {
+
+		if _, ok := vars[ident]; !ok && !strings.HasPrefix(ident, NonInputVariablePrefix) {
 			return fmt.Errorf("undefined var reference %v found in config", ident)
 		}
 	}


### PR DESCRIPTION
Added possibility to use go template range construct to entities templates. For example:
```
      vppConfig:
        vrfs:
          {{range $noninput_user_id := loop 1 ${USER_COUNT} }}
          # Special Vrf for user {{ $noninput_user_id }}
          - id: {{ $noninput_user_id }}
          {{- end}} 
```
where `USER_COUNT` is entity input variable and `noninput_user_id` is temporal loop variable (go template variable)

Note: the `noninput_` prefix is vital to identify variables not defined as entity input, because they need to be at some places in code handled in different way