### PR TITLE
swctl: added usage condition for entity's extra file

### DIFF
--- a/cmd/swctl/app/entity.go
+++ b/cmd/swctl/app/entity.go
@@ -123,6 +123,7 @@ type Entity struct {
 type ExtraFile struct {
 	Name    string `json:"name"`
 	Content string `json:"content"`
+	When    string `json:"when"`
 }
 
 func (e Entity) GetName() string {


### PR DESCRIPTION
Adds possibility to control creation of extra files from entity based on condition. For example this code will deploy given yaml only for demo deployment (DEMO_DEPLOYMENT is entity input variable)
```
    files:
      - name: "additional-config-for-demo.yaml"
        when: "${DEMO_DEPLOYMENT}"
        content: |
         ...
```
The condition is fully-evaluated template (just as entity config) and its content is evaluated (strconv.ParseBool) to find whether to create this file ("when" content is parsed to true boolean) or not ("when" content is parsed to false boolean).